### PR TITLE
Update to Godot 3.4.3

### DIFF
--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -1,8 +1,8 @@
 name: ☁ Headless Builds
-on: [push, pull_request]
+on: [push]
 
 env:
-  VERSION: 3.4.2-stable
+  VERSION: 3.4.3-stable
 
 jobs:
   mac-editor:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Godot Engine headless builds for macOS
 
-This repository builds macOS headless binaries based on the latest stable version of Godot (currently 3.4.2).
+This repository builds macOS headless binaries based on the latest stable version of Godot (currently 3.4.3).
 For more info on Godot, check its [website](https://godotengine.org) or its [GitHub repository](https://github.com/godotengine/godot).


### PR DESCRIPTION
I also made the workflow only run on push and not pull request, to avoid compiling the whole engine twice.