### PR TITLE
Update to 3.5.2

### DIFF
--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -2,7 +2,7 @@ name: ☁ Headless Builds
 on: [push]
 
 env:
-  VERSION: 4.0-stable
+  VERSION: 3.5.2-stable
 
 jobs:
   mac-editor:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Godot Engine headless builds for macOS
 
-This repository builds macOS headless binaries based on the latest stable version of Godot (currently 3.5.1).
+This repository builds macOS headless binaries based on the latest stable version of Godot (currently 3.5.2).
 For more info on Godot, check its [website](https://godotengine.org) or its [GitHub repository](https://github.com/godotengine/godot).


### PR DESCRIPTION
https://github.com/godotengine/godot/releases/tag/3.5.2-stable

Even though 4.0 is out, we should probably still keep the 3.x versions updated. I do not think 4.x versions need a headless build anymore, now that the normal build can run in proper headless mode.